### PR TITLE
Correct MTU to uint32_t

### DIFF
--- a/draft-troan-6man-universal-ra-option.xml
+++ b/draft-troan-6man-universal-ra-option.xml
@@ -253,7 +253,7 @@
    |   ? nat64: nat64				     |		 |
    |   ? ipv6-only: bool			     |		 |
    |   ? pvd : pvd				     |		 |
-   |   ? mtu : uint .size 2			     |		 |
+   |   ? mtu : uint .size 4			     |		 |
    |   ? rio : rio				     |		 |
    | }						     |		 |
    |                                                 |           |
@@ -269,7 +269,7 @@
    |   prefix : tstr				     |		 |
    |   ? preference : (0..3)			     |		 |
    |   ? lifetime : uint			     |		 |
-   |   ? mtu : uint .size 2			     | [this]    |
+   |   ? mtu : uint .size 4			     | [this]    |
    | }						     |		 |
    | rio = {					     |		 |
    |   routes : [+ rio_route]			     |		 |


### PR DESCRIPTION
Fix MTU .size from 2 to 4.  This matches the 4 byte size specified in:
    
    [1] RFC 2675 section 2 (Jumbo Payload Length)
    [2] RFC 4861 section 4.6.4. (MTU ND option)

Apologies for the error.